### PR TITLE
test: remove unnecessary ±1 tolerance in blackbox tests

### DIFF
--- a/nozzle_blackbox_test.go
+++ b/nozzle_blackbox_test.go
@@ -360,7 +360,7 @@ func TestNozzleDoBoolBlackbox(t *testing.T) { //nolint:tparallel // sub-tests sh
 				})
 			}
 
-			if expected := int(1000 * (float64(second.flowRate) / 100)); calls-expected > 1 || calls-expected < -1 {
+			if expected := int(1000 * (float64(second.flowRate) / 100)); calls != expected {
 				t.Errorf("Calls want=%d got=%d", expected, calls)
 			}
 
@@ -440,7 +440,7 @@ func TestNozzleDoErrorBlackbox(t *testing.T) { //nolint:tparallel // sub-tests s
 				}
 			}
 
-			if expected := int(1000 * (float64(second.flowRate) / 100)); calls-expected > 1 || calls-expected < -1 {
+			if expected := int(1000 * (float64(second.flowRate) / 100)); calls != expected {
 				t.Errorf("Calls want=%d got=%d", expected, calls)
 			}
 


### PR DESCRIPTION
> **Note**: This PR title, description, and code were generated with [Claude Code](https://claude.ai/code)

## Summary
- Removed the ±1 tolerance from call count assertions in blackbox tests
- Tests pass without any failures, confirming the algorithm's precision

## Background
The blackbox tests had a tolerance allowing call counts to be off by ±1:
```go
if expected := int(1000 * (float64(second.flowRate) / 100)); calls-expected > 1 || calls-expected < -1
```

This tolerance appeared to be defensive coding to handle potential rounding errors in the flow control algorithm.

## Analysis
After investigation, the flow control algorithm is mathematically precise:
- Uses cumulative `allowed` and `blocked` counters
- Calculates `allowRate = (allowed * 100) / total`
- Makes deterministic allow/block decisions based on `allowRate < flowRate`

This creates a self-correcting feedback loop that naturally converges to the exact target rate.

## Test Results
Both blackbox tests pass without any failures after removing the tolerance:
- `TestNozzleDoBoolBlackbox` - PASS (68 seconds)
- `TestNozzleDoErrorBlackbox` - PASS (61 seconds)

All flow rates (100%, 99%, 97%, down to 0%) produce exactly the expected number of calls.

## Conclusion
The ±1 tolerance was unnecessary. The algorithm produces exact results, making this defensive code removable.

🤖 Generated with [Claude Code](https://claude.ai/code)