### PR TITLE
refactor: simplify allowRate calculation logic

### DIFF
--- a/nozzle.go
+++ b/nozzle.go
@@ -362,21 +362,19 @@ func (n *Nozzle[T]) DoBool(callback func() (T, bool)) (T, bool) {
 		return *new(T), false
 	}
 
-	var allowRate int64
-
-	if n.allowed != 0 {
-		total := n.allowed + n.blocked
-		if total > 0 {
-			allowRate = (n.allowed * 100) / total
-		}
-	}
-
 	var allow bool
 
 	if n.flowRate == 100 {
 		allow = true
 	} else if n.flowRate > 0 {
-		allow = allowRate < n.flowRate
+		total := n.allowed + n.blocked
+		if total > 0 {
+			allowRate := (n.allowed * 100) / total
+			allow = allowRate < n.flowRate
+		} else {
+			// When no operations have been tracked yet, allow the operation
+			allow = true
+		}
 	}
 
 	if !allow {
@@ -436,21 +434,19 @@ func (n *Nozzle[T]) DoError(callback func() (T, error)) (T, error) {
 		return *new(T), ErrClosed
 	}
 
-	var allowRate int64
-
-	if n.allowed != 0 {
-		total := n.allowed + n.blocked
-		if total > 0 {
-			allowRate = (n.allowed * 100) / total
-		}
-	}
-
 	var allow bool
 
 	if n.flowRate == 100 {
 		allow = true
 	} else if n.flowRate > 0 {
-		allow = allowRate < n.flowRate
+		total := n.allowed + n.blocked
+		if total > 0 {
+			allowRate := (n.allowed * 100) / total
+			allow = allowRate < n.flowRate
+		} else {
+			// When no operations have been tracked yet, allow the operation
+			allow = true
+		}
 	}
 
 	if !allow {


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with [Claude Code](https://claude.ai/code)

## Summary
- Removes redundant checks in the allowRate calculation logic
- Optimizes performance by only calculating when needed
- Makes code cleaner and more maintainable

## Changes
This PR simplifies the `allowRate` calculation in both `DoBool` and `DoError` methods by:

1. **Removing redundant `if n.allowed != 0` check**: This check is unnecessary because if `allowed=0` and `blocked=0`, the `total > 0` check catches it. If `allowed=0` and `blocked>0`, we still need to calculate `allowRate`.

2. **Moving calculation to where it's needed**: The `allowRate` is now only calculated when `flowRate` is between 1-99, not when it's 100 (always allow) or 0 (always block).

3. **Making `allowRate` a local variable**: Since it's only used within the specific condition block, it's now scoped appropriately.

## Testing
- ✅ All existing tests pass
- ✅ 100% code coverage maintained
- ✅ Benchmarks show no performance regression (0 allocations maintained)

```
make test
...
PASS
coverage: 100.0% of statements
ok      github.com/justindfuller/nozzle        76.803s coverage: 100.0% of statements
```

```
make bench
...
BenchmarkNozzle_DoBool_Open-4          423092       2890 ns/op       0 B/op       0 allocs/op
BenchmarkNozzle_DoBool_Closed-4       1393106        769.5 ns/op     0 B/op       0 allocs/op
...
```

## Impact
This is a pure refactoring with no behavioral changes. The simplified logic is easier to understand and maintain while providing identical functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)