### PR TITLE
fix: use floating-point value for coverage threshold

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        # default fetch-depth is insufficient to find previous coverage notes
+        fetch-depth: 10
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -39,7 +42,7 @@ jobs:
       with:
         # Optional coverage threshold
         # use fail-coverage to determine what should happen below this threshold
-        coverage-threshold: 100
+        coverage-threshold: 99.9
         cover-pkg: ./...
         add-comment: false
         fail-coverage: false


### PR DESCRIPTION
> [!NOTE]
> This PR title, description, and code changes were generated with [Claude Code](https://claude.ai/code).

## Summary
- Changed coverage-threshold from `100` to `99.9` to work around floating-point precision issue
- Added `fetch-depth: 10` to checkout action to fix git log error

## Problems Fixed

### 1. Coverage Threshold Issue
The `gwatts/go-coverage-action@v2` was reporting that "coverage of 100.0% falls below the minimum threshold of 100%", despite having 100% coverage. This is a known floating-point precision issue where the actual coverage might be 99.9999% internally.

### 2. Git Log Error
The action was showing "Failed to run git log --notes=gocoverage" because the default `fetch-depth: 1` only fetches a single commit. The coverage action needs access to git history to retrieve previous coverage notes for comparison.

## Solutions
1. Set threshold to `99.9` to avoid floating-point equality comparison while maintaining effectively 100% coverage
2. Set `fetch-depth: 10` to provide sufficient git history for the coverage action to access previous coverage notes

## Test plan
- [ ] GitHub Actions workflow passes without coverage warnings
- [ ] No "Failed to run git log" errors
- [ ] Coverage badge shows green when coverage is 100%

🤖 Generated with [Claude Code](https://claude.ai/code)