### PR TITLE
Fix: Make OnStateChange callbacks non-blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ As you can see, this package uses generics. This allows the Nozzle's methods to 
 
 You may want to collect metrics to help you observe when your nozzle is opening and closing. You can accomplish this with `nozzle.OnStateChange`. `OnStateChange` will be called _at most_ once per `Interval` but only if a change occurred.
 
-**BREAKING CHANGE in v2:** The callback now receives a `context.Context` as the first parameter, which is cancelled when the nozzle closes.
-
 The callback receives a context and a `StateSnapshot` containing an immutable copy of the nozzle's state, ensuring thread-safe access to state information:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -188,15 +188,26 @@ As you can see, this package uses generics. This allows the Nozzle's methods to 
 
 You may want to collect metrics to help you observe when your nozzle is opening and closing. You can accomplish this with `nozzle.OnStateChange`. `OnStateChange` will be called _at most_ once per `Interval` but only if a change occurred.
 
-The callback receives a `StateSnapshot` containing an immutable copy of the nozzle's state, ensuring thread-safe access to state information:
+**BREAKING CHANGE in v2:** The callback now receives a `context.Context` as the first parameter, which is cancelled when the nozzle closes.
+
+The callback receives a context and a `StateSnapshot` containing an immutable copy of the nozzle's state, ensuring thread-safe access to state information:
 
 ```go
 n, err := nozzle.New(nozzle.Options[*example]{
     Interval:              time.Second,
     AllowedFailurePercent: 50,
-    OnStateChange: func(snapshot nozzle.StateSnapshot) {
+    OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+        // Check if nozzle is shutting down
+        select {
+        case <-ctx.Done():
+            return
+        default:
+        }
+        
         logger.Info(
             "Nozzle State Change",
+            "timestamp",
+            snapshot.Timestamp.Format(time.RFC3339),
             "state",
             snapshot.State,
             "flowRate",
@@ -210,6 +221,7 @@ n, err := nozzle.New(nozzle.Options[*example]{
          Example output:
          {
             "message": "Nozzle State Change",
+            "timestamp": "2024-01-15T10:30:45Z",
             "state": "opening",
             "flowRate": 50,
             "failureRate": 20,
@@ -222,10 +234,12 @@ n, err := nozzle.New(nozzle.Options[*example]{
 
 ### Callback Execution Guarantees
 
-- Callbacks are called **sequentially** (never concurrently)
-- Callbacks are called **at most once per interval**
+- Callbacks are executed **asynchronously** in separate goroutines (may run concurrently)
+- Callbacks are called **at most once per interval** when state changes
 - Panics in callbacks are recovered and don't affect nozzle operation
-- Long-running callbacks may delay subsequent state calculations
+- Callbacks don't block the ticker or state calculations
+- The context is cancelled when the nozzle closes, signaling callbacks to stop
+- The `Timestamp` field indicates when the state change occurred, not when the callback executes
 
 For more details on OnStateChange behavior and thread safety considerations, see the [documentation](documentation/on_state_change.md).
 

--- a/README.md
+++ b/README.md
@@ -196,10 +196,8 @@ n, err := nozzle.New(nozzle.Options[*example]{
     AllowedFailurePercent: 50,
     OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
         // Check if nozzle is shutting down
-        select {
-        case <-ctx.Done():
+        if ctx.Err() != nil {
             return
-        default:
         }
         
         logger.Info(

--- a/documentation/observability_otel_example.md
+++ b/documentation/observability_otel_example.md
@@ -45,10 +45,8 @@ func setupNozzleWithMetrics[T any](opts nozzle.Options[T]) (*nozzle.Nozzle[T], e
     // Configure OnStateChange to update metrics
     opts.OnStateChange = func(ctx context.Context, snapshot nozzle.StateSnapshot) {
         // Check if nozzle is shutting down
-        select {
-        case <-ctx.Done():
+        if ctx.Err() != nil {
             return
-        default:
         }
         
         // Update gauge value

--- a/documentation/observability_otel_example.md
+++ b/documentation/observability_otel_example.md
@@ -43,7 +43,14 @@ func setupNozzleWithMetrics[T any](opts nozzle.Options[T]) (*nozzle.Nozzle[T], e
     )
     
     // Configure OnStateChange to update metrics
-    opts.OnStateChange = func(snapshot nozzle.StateSnapshot) {
+    opts.OnStateChange = func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+        // Check if nozzle is shutting down
+        select {
+        case <-ctx.Done():
+            return
+        default:
+        }
+        
         // Update gauge value
         latestFlowRate = float64(snapshot.FlowRate)
         
@@ -52,6 +59,7 @@ func setupNozzleWithMetrics[T any](opts nozzle.Options[T]) (*nozzle.Nozzle[T], e
             metric.WithAttributes(
                 attribute.String("state", string(snapshot.State)),
                 attribute.Int64("flow_rate", snapshot.FlowRate),
+                attribute.String("timestamp", snapshot.Timestamp.Format(time.RFC3339)),
             ))
     }
     
@@ -88,6 +96,8 @@ result, err := n.DoError(func() (any, error) {
 ## Key Points
 
 - The `StateSnapshot` passed to `OnStateChange` provides thread-safe access to all metrics
+- The `Timestamp` field indicates when the state change occurred
 - Observable gauges are ideal for point-in-time values like flow rate
-- The callback executes synchronously during state calculation, so avoid blocking operations
+- The callback executes asynchronously in a separate goroutine and doesn't block the ticker
 - Metrics are only recorded when state actually changes (at most once per interval)
+- The context is cancelled when the nozzle closes, allowing graceful callback shutdown

--- a/nozzle.go
+++ b/nozzle.go
@@ -184,8 +184,6 @@ type Options[T any] struct {
 	// state changes. The callback receives a context (cancelled on Close) and a StateSnapshot
 	// containing an immutable copy of the nozzle's state at the time of the change.
 	//
-	// BREAKING CHANGE in v2: Added context.Context as first parameter.
-	//
 	// Execution guarantees:
 	//  - Called at most once per Interval, only when state actually changes
 	//  - Called asynchronously in separate goroutines (may run concurrently)

--- a/nozzle.go
+++ b/nozzle.go
@@ -207,13 +207,11 @@ type Options[T any] struct {
 	// Example - Metrics integration with cancellation check:
 	//
 	//	OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
-	//	    select {
-	//	    case <-ctx.Done():
+	//	    if ctx.Err() != nil {
 	//	        return // Nozzle is closing
-	//	    default:
-	//	        metrics.SetGauge("nozzle.flow_rate", float64(snapshot.FlowRate))
-	//	        metrics.SetGauge("nozzle.failure_rate", float64(snapshot.FailureRate))
 	//	    }
+	//	    metrics.SetGauge("nozzle.flow_rate", float64(snapshot.FlowRate))
+	//	    metrics.SetGauge("nozzle.failure_rate", float64(snapshot.FailureRate))
 	//	}
 	//
 	// Example - Alerting on degradation:

--- a/nozzle.go
+++ b/nozzle.go
@@ -5,6 +5,7 @@
 package nozzle
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -114,7 +115,7 @@ type Nozzle[T any] struct {
 //
 // Example usage:
 //
-//	OnStateChange: func(snapshot nozzle.StateSnapshot) {
+//	OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
 //	    if snapshot.FlowRate < 50 {
 //	        log.Printf("WARNING: Flow restricted to %d%%", snapshot.FlowRate)
 //	    }
@@ -122,6 +123,10 @@ type Nozzle[T any] struct {
 //	    metrics.SetGauge("nozzle.failure_rate", float64(snapshot.FailureRate))
 //	}
 type StateSnapshot struct {
+	// Timestamp indicates when this state change occurred.
+	// This represents the actual time of the state change, not when the callback executes.
+	Timestamp time.Time
+
 	// FlowRate is the current percentage of operations allowed through (0-100).
 	// When FlowRate is 100, all operations are allowed. When 0, all operations are blocked.
 	// The rate adjusts dynamically based on success/failure ratios.
@@ -176,47 +181,51 @@ type Options[T any] struct {
 	AllowedFailurePercent int64
 
 	// OnStateChange is an optional callback function invoked whenever the nozzle's
-	// state changes. The callback receives a StateSnapshot containing an immutable copy
-	// of the nozzle's state at the time of the change.
+	// state changes. The callback receives a context (cancelled on Close) and a StateSnapshot
+	// containing an immutable copy of the nozzle's state at the time of the change.
+	//
+	// BREAKING CHANGE in v2: Added context.Context as first parameter.
 	//
 	// Execution guarantees:
 	//  - Called at most once per Interval, only when state actually changes
-	//  - Called sequentially (never concurrently) even with multiple nozzles
-	//  - Called while holding the nozzle's mutex (thread-safe but avoid blocking operations)
+	//  - Called asynchronously in separate goroutines (may run concurrently)
+	//  - Callbacks may execute out of order during rapid state changes
 	//  - Panics in callbacks are recovered and don't affect nozzle operation
+	//  - Context is cancelled when nozzle.Close() is called
 	//
 	// Performance considerations:
-	//  - The callback executes synchronously during state calculation
-	//  - Long-running callbacks may delay subsequent state calculations
+	//  - Callbacks execute asynchronously and don't block the ticker
 	//  - StateSnapshot is passed by value (zero allocations, minimal overhead)
-	//  - Avoid heavy operations; consider queueing work for async processing
+	//  - For long-running operations, check ctx.Done() to handle cancellation
 	//
 	// Example - Basic logging:
 	//
-	//	OnStateChange: func(snapshot nozzle.StateSnapshot) {
-	//	    log.Printf("State: %s, Flow: %d%%, Failures: %d%%",
-	//	        snapshot.State, snapshot.FlowRate, snapshot.FailureRate)
+	//	OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+	//	    log.Printf("State: %s, Flow: %d%%, Failures: %d%% at %s",
+	//	        snapshot.State, snapshot.FlowRate, snapshot.FailureRate,
+	//	        snapshot.Timestamp.Format(time.RFC3339))
 	//	}
 	//
-	// Example - Metrics integration:
+	// Example - Metrics integration with cancellation check:
 	//
-	//	OnStateChange: func(snapshot nozzle.StateSnapshot) {
-	//	    metrics.SetGauge("nozzle.flow_rate", float64(snapshot.FlowRate))
-	//	    metrics.SetGauge("nozzle.failure_rate", float64(snapshot.FailureRate))
-	//	    if snapshot.State == nozzle.Closing {
-	//	        metrics.Increment("nozzle.closing_events")
+	//	OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+	//	    select {
+	//	    case <-ctx.Done():
+	//	        return // Nozzle is closing
+	//	    default:
+	//	        metrics.SetGauge("nozzle.flow_rate", float64(snapshot.FlowRate))
+	//	        metrics.SetGauge("nozzle.failure_rate", float64(snapshot.FailureRate))
 	//	    }
 	//	}
 	//
 	// Example - Alerting on degradation:
 	//
-	//	OnStateChange: func(snapshot nozzle.StateSnapshot) {
+	//	OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
 	//	    if snapshot.FlowRate < 25 {
-	//	        // Queue alert asynchronously to avoid blocking
-	//	        go alerting.Send("Critical: Flow rate at %d%%", snapshot.FlowRate)
+	//	        alerting.Send("Critical: Flow rate at %d%%", snapshot.FlowRate)
 	//	    }
 	//	}
-	OnStateChange func(StateSnapshot)
+	OnStateChange func(context.Context, StateSnapshot)
 }
 
 // State describes the current direction the Nozzle is moving.
@@ -286,10 +295,13 @@ func New[T any](options Options[T]) (*Nozzle[T], error) {
 // tick periodically invokes the calculate method based on the Nozzle's interval.
 // It ensures the Nozzle processes its state updates at regular intervals.
 func (n *Nozzle[T]) tick() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for {
 		select {
 		case <-n.timeTicker.C:
-			n.calculate()
+			n.calculate(ctx)
 		case <-n.done:
 			return
 		}
@@ -471,7 +483,7 @@ func (n *Nozzle[T]) DoError(callback func() (T, error)) (T, error) {
 
 // calculate updates the Nozzle's state based on the elapsed time and failure rate.
 // It determines whether to open or close the Nozzle and triggers the ticker if necessary.
-func (n *Nozzle[T]) calculate() {
+func (n *Nozzle[T]) calculate(ctx context.Context) {
 	n.mut.Lock()
 	defer n.mut.Unlock()
 
@@ -502,8 +514,8 @@ func (n *Nozzle[T]) calculate() {
 
 	if changed && n.Options.OnStateChange != nil {
 		// Create an immutable snapshot of the current state.
-		// This is safe to pass to the callback without unlocking the mutex.
 		snapshot := StateSnapshot{
+			Timestamp:   time.Now(),
 			FlowRate:    n.flowRate,
 			State:       n.state,
 			FailureRate: n.failureRate(),
@@ -512,9 +524,16 @@ func (n *Nozzle[T]) calculate() {
 			Blocked:     n.blocked,
 		}
 
-		// Call the callback with the snapshot.
-		// The mutex remains locked, preventing race conditions.
-		n.Options.OnStateChange(snapshot)
+		// Spawn goroutine to call callback asynchronously.
+		// This prevents slow callbacks from blocking the ticker.
+		go func() {
+			defer func() {
+				// Recover from panics in callbacks to prevent crashes
+				_ = recover()
+			}()
+
+			n.Options.OnStateChange(ctx, snapshot)
+		}()
 	}
 
 	n.reset()

--- a/nozzle_bench_test.go
+++ b/nozzle_bench_test.go
@@ -183,7 +183,7 @@ func BenchmarkNozzle_StateSnapshot(b *testing.B) {
 	noz, err := nozzle.New(nozzle.Options[any]{
 		Interval:              time.Millisecond * 10,
 		AllowedFailurePercent: 30,
-		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+		OnStateChange: func(_ context.Context, snapshot nozzle.StateSnapshot) {
 			// Simulate accessing snapshot fields as would happen in real usage
 			// Access fields to ensure they're included in benchmark measurements
 			if snapshot.Timestamp.IsZero() || snapshot.FlowRate < 0 || snapshot.State == "" ||

--- a/nozzle_bench_test.go
+++ b/nozzle_bench_test.go
@@ -1,6 +1,7 @@
 package nozzle_test
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -182,10 +183,10 @@ func BenchmarkNozzle_StateSnapshot(b *testing.B) {
 	noz, err := nozzle.New(nozzle.Options[any]{
 		Interval:              time.Millisecond * 10,
 		AllowedFailurePercent: 30,
-		OnStateChange: func(snapshot nozzle.StateSnapshot) {
+		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
 			// Simulate accessing snapshot fields as would happen in real usage
 			// Access fields to ensure they're included in benchmark measurements
-			if snapshot.FlowRate < 0 || snapshot.State == "" ||
+			if snapshot.Timestamp.IsZero() || snapshot.FlowRate < 0 || snapshot.State == "" ||
 				snapshot.FailureRate < 0 || snapshot.SuccessRate < 0 ||
 				snapshot.Allowed < 0 || snapshot.Blocked < 0 {
 				// This should never happen but ensures fields are accessed

--- a/nozzle_callback_test.go
+++ b/nozzle_callback_test.go
@@ -1,0 +1,266 @@
+package nozzle_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/justindfuller/nozzle"
+)
+
+// TestSlowCallbackDoesNotBlockTicker verifies that a slow OnStateChange callback
+// doesn't prevent the ticker from continuing to process state calculations.
+func TestSlowCallbackDoesNotBlockTicker(t *testing.T) {
+	t.Parallel()
+
+	var (
+		callbackStarted   atomic.Bool
+		callbackCompleted atomic.Bool
+		tickCount         atomic.Int32
+	)
+
+	// Create nozzle with a very short interval
+	n, err := nozzle.New(nozzle.Options[any]{
+		Interval:              10 * time.Millisecond,
+		AllowedFailurePercent: 50,
+		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+			callbackStarted.Store(true)
+			// Simulate a slow callback that takes longer than the interval
+			time.Sleep(100 * time.Millisecond)
+			callbackCompleted.Store(true)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create nozzle: %v", err)
+	}
+	defer n.Close()
+
+	// Track when ticks happen by monitoring state changes
+	go func() {
+		for i := range 15 {
+			// Force operations to trigger state changes
+			n.DoBool(func() (any, bool) {
+				return nil, i%2 == 0
+			})
+			time.Sleep(10 * time.Millisecond)
+			tickCount.Add(1)
+		}
+	}()
+
+	// Wait for callback to start
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for !callbackStarted.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !callbackStarted.Load() {
+		t.Fatal("Callback never started")
+	}
+
+	// Record tick count when callback is still running
+	ticksWhileCallbackRunning := tickCount.Load()
+
+	// Wait for callback to complete
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for !callbackCompleted.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !callbackCompleted.Load() {
+		t.Fatal("Callback never completed")
+	}
+
+	finalTicks := tickCount.Load()
+
+	// Verify that ticks continued while callback was running
+	// We expect at least a few ticks to have occurred during the 100ms callback
+	ticksDuringCallback := finalTicks - ticksWhileCallbackRunning
+	if ticksDuringCallback < 2 {
+		t.Errorf("Expected ticker to continue during slow callback, but only got %d ticks", ticksDuringCallback)
+	}
+
+	t.Logf("Ticks during callback: %d", ticksDuringCallback)
+}
+
+// TestCallbackPanicRecovery verifies that panics in callbacks are recovered
+// and don't crash the program or affect nozzle operation.
+func TestCallbackPanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	var (
+		panicCallbackInvoked atomic.Bool
+		normalCallbackCount  atomic.Int32
+	)
+
+	n, err := nozzle.New(nozzle.Options[any]{
+		Interval:              10 * time.Millisecond,
+		AllowedFailurePercent: 50,
+		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+			if !panicCallbackInvoked.Load() {
+				panicCallbackInvoked.Store(true)
+				panic("intentional test panic")
+			}
+			normalCallbackCount.Add(1)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create nozzle: %v", err)
+	}
+	defer n.Close()
+
+	// Trigger state changes
+	for i := range 50 {
+		n.DoBool(func() (any, bool) {
+			return nil, i%3 == 0
+		})
+
+		if i%10 == 0 {
+			time.Sleep(15 * time.Millisecond)
+		}
+	}
+
+	// Wait a bit for callbacks to process
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the panic happened and was recovered
+	if !panicCallbackInvoked.Load() {
+		t.Error("Panic callback was never invoked")
+	}
+
+	// Verify subsequent callbacks still work
+	if normalCallbackCount.Load() == 0 {
+		t.Error("No normal callbacks executed after panic")
+	}
+
+	// Verify nozzle is still operational
+	_, ok := n.DoBool(func() (any, bool) {
+		return nil, true
+	})
+	if !ok {
+		t.Error("Nozzle stopped working after callback panic")
+	}
+
+	t.Logf("Normal callbacks after panic: %d", normalCallbackCount.Load())
+}
+
+// TestCallbackContextCancellation verifies that callbacks receive a cancelled
+// context when the nozzle is closed.
+func TestCallbackContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	var (
+		callbackStarted     atomic.Bool
+		contextWasCancelled atomic.Bool
+	)
+
+	n, err := nozzle.New(nozzle.Options[any]{
+		Interval:              10 * time.Millisecond,
+		AllowedFailurePercent: 50,
+		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+			callbackStarted.Store(true)
+
+			// Wait a bit then check if context is cancelled
+			time.Sleep(50 * time.Millisecond)
+
+			select {
+			case <-ctx.Done():
+				contextWasCancelled.Store(true)
+			default:
+				// Context not cancelled
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create nozzle: %v", err)
+	}
+
+	// Trigger a state change
+	for range 10 {
+		n.DoBool(func() (any, bool) {
+			return nil, false
+		})
+	}
+
+	// Wait for callback to start
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for !callbackStarted.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !callbackStarted.Load() {
+		t.Fatal("Callback never started")
+	}
+
+	// Close the nozzle while callback is running
+	n.Close()
+
+	// Wait a bit for callback to detect cancellation
+	time.Sleep(100 * time.Millisecond)
+
+	if !contextWasCancelled.Load() {
+		t.Error("Callback context was not cancelled when nozzle closed")
+	}
+}
+
+// TestCallbackTimestampAccuracy verifies that the Timestamp field
+// accurately reflects when the state change occurred.
+func TestCallbackTimestampAccuracy(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu         sync.Mutex
+		timestamps []time.Time
+	)
+
+	n, err := nozzle.New(nozzle.Options[any]{
+		Interval:              50 * time.Millisecond,
+		AllowedFailurePercent: 50,
+		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+			mu.Lock()
+			timestamps = append(timestamps, snapshot.Timestamp)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create nozzle: %v", err)
+	}
+	defer n.Close()
+
+	// Trigger state changes
+	for i := range 30 {
+		n.DoBool(func() (any, bool) {
+			return nil, i%2 == 0
+		})
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait for callbacks to complete
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(timestamps) < 2 {
+		t.Fatalf("Not enough timestamps collected: %d", len(timestamps))
+	}
+
+	// Verify timestamps are set and increasing
+	var lastTimestamp time.Time
+
+	for i, ts := range timestamps {
+		if ts.IsZero() {
+			t.Errorf("Timestamp %d is zero", i)
+		}
+
+		if !lastTimestamp.IsZero() && ts.Before(lastTimestamp) {
+			t.Errorf("Timestamp %d (%v) is before previous timestamp (%v)",
+				i, ts, lastTimestamp)
+		}
+
+		lastTimestamp = ts
+	}
+
+	t.Logf("Collected %d timestamps, all valid and increasing", len(timestamps))
+}

--- a/nozzle_callback_test.go
+++ b/nozzle_callback_test.go
@@ -22,7 +22,7 @@ func TestSlowCallbackDoesNotBlockTicker(t *testing.T) {
 	)
 
 	// Create nozzle with a very short interval
-	n, err := nozzle.New(nozzle.Options[any]{
+	noz, err := nozzle.New(nozzle.Options[any]{
 		Interval:              10 * time.Millisecond,
 		AllowedFailurePercent: 50,
 		OnStateChange: func(_ context.Context, _ nozzle.StateSnapshot) {
@@ -35,8 +35,9 @@ func TestSlowCallbackDoesNotBlockTicker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create nozzle: %v", err)
 	}
+
 	defer func() {
-		if err := n.Close(); err != nil {
+		if err := noz.Close(); err != nil {
 			t.Errorf("Failed to close nozzle: %v", err)
 		}
 	}()
@@ -45,7 +46,7 @@ func TestSlowCallbackDoesNotBlockTicker(t *testing.T) {
 	go func() {
 		for i := range 15 {
 			// Force operations to trigger state changes
-			n.DoBool(func() (any, bool) {
+			noz.DoBool(func() (any, bool) {
 				return nil, i%2 == 0
 			})
 			time.Sleep(10 * time.Millisecond)
@@ -112,6 +113,7 @@ func TestCallbackPanicRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create nozzle: %v", err)
 	}
+
 	defer func() {
 		if err := noz.Close(); err != nil {
 			t.Errorf("Failed to close nozzle: %v", err)
@@ -224,7 +226,7 @@ func TestCallbackTimestampAccuracy(t *testing.T) {
 		timestamps []time.Time
 	)
 
-	n, err := nozzle.New(nozzle.Options[any]{
+	noz, err := nozzle.New(nozzle.Options[any]{
 		Interval:              50 * time.Millisecond,
 		AllowedFailurePercent: 50,
 		OnStateChange: func(_ context.Context, snapshot nozzle.StateSnapshot) {
@@ -236,15 +238,16 @@ func TestCallbackTimestampAccuracy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create nozzle: %v", err)
 	}
+
 	defer func() {
-		if err := n.Close(); err != nil {
+		if err := noz.Close(); err != nil {
 			t.Errorf("Failed to close nozzle: %v", err)
 		}
 	}()
 
 	// Trigger state changes
 	for i := range 30 {
-		n.DoBool(func() (any, bool) {
+		noz.DoBool(func() (any, bool) {
 			return nil, i%2 == 0
 		})
 		time.Sleep(10 * time.Millisecond)

--- a/nozzle_example_test.go
+++ b/nozzle_example_test.go
@@ -268,18 +268,18 @@ func ExampleOptions() {
 	// Use a synchronous approach for deterministic example output
 	var (
 		outputs []string
-		mu      sync.Mutex
+		mutex   sync.Mutex
 	)
 
 	noz, err := nozzle.New(nozzle.Options[[]string]{
 		Interval:              time.Second,
 		AllowedFailurePercent: 50,
-		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+		OnStateChange: func(_ context.Context, snapshot nozzle.StateSnapshot) {
 			output := fmt.Sprintf("New State: %s\nFailure Rate: %d\nSuccess Rate: %d\nFlow Rate: %d",
 				snapshot.State, snapshot.FailureRate, snapshot.SuccessRate, snapshot.FlowRate)
-			mu.Lock()
+			mutex.Lock()
 			outputs = append(outputs, output)
-			mu.Unlock()
+			mutex.Unlock()
 		},
 	})
 	if err != nil {
@@ -314,13 +314,13 @@ func ExampleOptions() {
 	time.Sleep(100 * time.Millisecond)
 
 	// Print collected outputs
-	mu.Lock()
+	mutex.Lock()
 
 	for _, output := range outputs {
 		fmt.Println(output)
 	}
 
-	mu.Unlock()
+	mutex.Unlock()
 
 	// Output:
 	// New State: closing

--- a/nozzle_race_test.go
+++ b/nozzle_race_test.go
@@ -20,7 +20,7 @@ func TestNozzleSnapshotFieldValidation(t *testing.T) {
 	noz, err := nozzle.New(nozzle.Options[string]{
 		Interval:              50 * time.Millisecond,
 		AllowedFailurePercent: 30,
-		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+		OnStateChange: func(_ context.Context, snapshot nozzle.StateSnapshot) {
 			validationCount.Add(1)
 
 			// Validate timestamp is set
@@ -114,7 +114,7 @@ func TestNozzleConcurrentStateChange(t *testing.T) {
 	noz, err := nozzle.New(nozzle.Options[string]{
 		Interval:              50 * time.Millisecond,
 		AllowedFailurePercent: 30,
-		OnStateChange: func(ctx context.Context, _ nozzle.StateSnapshot) {
+		OnStateChange: func(_ context.Context, _ nozzle.StateSnapshot) {
 			// Simply count callbacks - no validation here
 			callbackCount.Add(1)
 		},
@@ -187,24 +187,24 @@ func TestNozzleCallbackNoDeadlock(t *testing.T) {
 	}{
 		{
 			name: "EmptyCallback",
-			callback: func(ctx context.Context, _ nozzle.StateSnapshot) {
+			callback: func(_ context.Context, _ nozzle.StateSnapshot) {
 				// Do nothing
 			},
 		},
 		{
 			name: "SlowCallback",
-			callback: func(ctx context.Context, _ nozzle.StateSnapshot) {
+			callback: func(_ context.Context, _ nozzle.StateSnapshot) {
 				time.Sleep(10 * time.Millisecond)
 			},
 		},
 		{
 			name: "AccessAllFields",
-			callback: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+			callback: func(_ context.Context, snapshot nozzle.StateSnapshot) {
 				// Access all fields to verify no deadlock occurs
 				total := snapshot.FlowRate + snapshot.FailureRate + snapshot.SuccessRate
 				sum := snapshot.Allowed + snapshot.Blocked
 				// Use variables to avoid compiler warnings
-				if total < 0 || sum < 0 || snapshot.State == "" || snapshot.Timestamp.IsZero() {
+				if total < 0 || sum < 0 || snapshot.State == "" {
 					// This should never happen but satisfies the compiler
 					return
 				}
@@ -271,7 +271,7 @@ func TestNozzleRaceConditionRegression(t *testing.T) {
 	noz, err := nozzle.New(nozzle.Options[string]{
 		Interval:              10 * time.Millisecond,
 		AllowedFailurePercent: 50,
-		OnStateChange: func(ctx context.Context, snapshot nozzle.StateSnapshot) {
+		OnStateChange: func(_ context.Context, snapshot nozzle.StateSnapshot) {
 			// Store snapshot for later verification
 			snapshotMutex.Lock()
 			snapshots = append(snapshots, snapshot)


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with Claude Code (claude.ai/code)

## Summary
- Fixes the issue where slow OnStateChange callbacks could block the ticker and all nozzle operations
- Callbacks now execute asynchronously in separate goroutines
- Adds proper context cancellation support

## Problem
The OnStateChange callback was executed synchronously while holding the mutex lock. This meant:
1. A slow callback would delay the next ticker iteration
2. All DoBool/DoError operations would be blocked during callback execution
3. The ticker couldn't maintain its configured interval

## Solution
- Execute callbacks asynchronously using goroutines
- Add context.Context parameter for proper cancellation signaling
- Add Timestamp field to StateSnapshot to record when changes actually occurred
- Implement panic recovery to prevent callback crashes

## Breaking Changes
The callback signature has changed from:
```go
OnStateChange func(StateSnapshot)
```
to:
```go
OnStateChange func(context.Context, StateSnapshot)
```

## Testing
Added comprehensive tests to verify:
- Slow callbacks don't block the ticker
- Panics in callbacks are recovered gracefully
- Context is properly cancelled on Close()
- Timestamps accurately reflect state change times
- All existing tests continue to pass

## Test Results
```
PASS
ok  	github.com/justindfuller/nozzle	77.289s
```

🤖 Generated with [Claude Code](https://claude.ai/code)